### PR TITLE
"changes to run_spec to allow for feols model fits"

### DIFF
--- a/R/setup_specs.r
+++ b/R/setup_specs.r
@@ -24,42 +24,23 @@
 #'             all.comb = TRUE)
 #'
 #'@seealso [run_specs()] to run the specification curve analysis.
-setup_specs <- function(x,
-                        y,
-                        model,
-                        controls = NULL,
-                        all.comb = FALSE) {
-
-
+setup_specs <- function(x, y, model, controls = NULL, all.comb = FALSE) {
   if (!rlang::is_null(controls) & length(controls) == 1) {
-
-    controls <- list(controls, "no covariates") %>%
-      unlist
-
+    controls <- list(controls, "no covariates") %>% unlist
   } else if (!rlang::is_null(controls) & isFALSE(all.comb)) {
-
     controls <- list(controls %>% paste(collapse = " + "),
                      purrr::map(1:length(controls), ~controls[[.x]]),
-                     "no covariates") %>%
-      unlist
-
+                     "no covariates") %>% unlist
   } else if(!rlang::is_null(controls) & isTRUE(all.comb)) {
-
     controls <- list(do.call("c", lapply(seq_along(controls),
                                          function(i) utils::combn(controls, i, FUN = list))) %>%
                        map(function(x) paste(x, collapse = " + ")), "no covariates") %>%
       unlist
-
   } else {
-
     controls <- "no covariates"
-
   }
   # Expand to all possible combinations
-  expand.grid(x = x,
-              y = y,
-              model = model,
-              controls = controls) %>%
+  expand.grid(x = x, y = y, model = model, controls = controls) %>%
     dplyr::mutate_all(as.character) %>%
     as_tibble
 }


### PR DESCRIPTION
The `run_spec` helper function has a named argument `formula`, which makes it incompatible with the [fixest](https://lrberge.github.io/fixest/) package, which expects formulae to be called `fml`. Changing this to an un-named first argument makes this work with all model fitter functions that accept a formula as the first argument (including but not limited to `feols` and `lm`). 

The other changes are just code formatting performed by my editor. 