### PR TITLE
List all controls when specifying groups of covariates and `simplify=TRUE` 

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -179,6 +179,8 @@ setup <- function(data,
     stop("Subsets must be an object of class 'list'")
   }
 
+  original_controls <- controls
+
   if(isTRUE(simplify)) {
     controls <- expand_covariate_simple(controls)
   } else {
@@ -275,7 +277,9 @@ setup <- function(data,
   if(isTRUE(simplify)) {
 
     grid <- grid %>%
-      mutate(controls = ifelse(grepl("\\+", controls), "all covariates", controls))
+      mutate(controls = ifelse(grepl("\\+", controls) & !(controls %in% original_controls),
+                               "all covariates",
+                               controls))
 
   }
 
@@ -298,5 +302,4 @@ setup <- function(data,
     return(res)
 
 }
-
 

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -159,3 +159,17 @@ test_that("setup creates object of class `specr.setup`", {
                  simplify = TRUE)
   expect_true(inherits(specs, "specr.setup"))
 })
+
+# Test 12:
+
+test_that("setup preserves grouped control labels when simplified", {
+  specs <- specr::setup(data = example_data,
+                 x = "x1",
+                 y = "y1",
+                 model = "lm",
+                 controls = c("c1 + c2", "c3 + c4"),
+                 simplify = TRUE)
+
+  expect_equal(unique(specs$specs$controls),
+               c("no covariates", "c1 + c2", "c3 + c4", "all covariates"))
+})


### PR DESCRIPTION
Ensure `setup()` uses grouped control names when creating a specification with groups of controls (e.g. "c1 + c2" and "c3 + c4") and `simplify = TRUE`, while only the generated combined control set becomes "all covariates".

For example:

```
specs <- setup(
    data = example_data, 
    y = "y1", 
    x = "x1", 
    model = c("lm"),
    controls = c("c1 + c2", "c3 + c4"),
    simplify = TRUE
)

distinct(specs$specs, controls)
```

will return:
- no covariates 
- c1 + c2       
- c3 + c4       
- all covariates

whereas the current package only returns:
- no covariates
- all covariates