### PR TITLE
Simplify display of controls on choices panel

### DIFF
--- a/R/generics.r
+++ b/R/generics.r
@@ -534,8 +534,7 @@ plot.specr.object <- function(x,
 
   plot_b <- x$data %>%
     format_results(var = var, group = group, null = null, desc = desc) %>%
-    tidyr::gather(key, value, choices) %>%
-    dplyr::mutate(key = factor(key, levels = choices)) %>%
+    format_choice_panel(choices = choices) %>%
     ggplot(aes(x = .data$specifications,
                y = value,
                color = .data$color)) +
@@ -976,5 +975,4 @@ plot.specr.boot <- function(x, ...) {
     labs(x = "Specifications (ranked)", y = "estimate", color = "", linetype = "")
 
 }
-
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -86,11 +86,66 @@ format_results <- function(df, var, group, null = 0, desc = FALSE) {
   return(df)
 }
 
+format_choice_panel <- function(df, choices) {
+
+  value <- key <- NULL
+
+  choice_panel <- df %>%
+    tidyr::gather(key, value, choices) %>%
+    dplyr::mutate(key = factor(.data$key, levels = choices))
+
+  if (!"controls" %in% choices) {
+    return(choice_panel)
+  }
+
+  controls_rows <- choice_panel[as.character(choice_panel$key) == "controls", , drop = FALSE]
+
+  if (nrow(controls_rows) == 0) {
+    return(choice_panel)
+  }
+
+  other_rows <- choice_panel[as.character(choice_panel$key) != "controls", , drop = FALSE]
+
+  controls_values <- as.character(controls_rows$value)
+  individual_controls <- controls_values[
+    !is.na(controls_values) &
+      controls_values != "no covariates" &
+      controls_values != "all covariates" &
+      !grepl("\\+", controls_values)
+  ]
+  individual_controls <- unique(trimws(individual_controls))
+  individual_controls <- individual_controls[nzchar(individual_controls)]
+
+  split_control_values <- lapply(controls_values, function(value) {
+    if (is.na(value)) {
+      return(NA_character_)
+    }
+
+    value <- trimws(value)
+
+    if (value == "all covariates" && length(individual_controls) > 0) {
+      return(individual_controls)
+    }
+
+    if (grepl("\\+", value)) {
+      split_values <- trimws(strsplit(value, "\\+")[[1]])
+      return(split_values[nzchar(split_values)])
+    }
+
+    value
+  })
+
+  row_indices <- rep(seq_len(nrow(controls_rows)), lengths(split_control_values))
+  controls_rows <- controls_rows[row_indices, , drop = FALSE]
+  controls_rows$value <- unlist(split_control_values, use.names = FALSE)
+
+  dplyr::bind_rows(other_rows, controls_rows)
+}
+
 # get names from dots
 names_from_dots <- function(...) {
 
   sapply(substitute(list(...))[-1], deparse)
 
 }
-
 

--- a/tests/testthat/test-generics.R
+++ b/tests/testthat/test-generics.R
@@ -34,6 +34,40 @@ test_that("Function plot.specr.object with `type = 'choices'` creates a ggplot",
   expect_is(p, "gg")
 })
 
+test_that("control combinations are expanded in the strike plot", {
+  p <- plot(results, type = "choices", choices = "controls")
+
+  expect_false("c1 + c2" %in% p$data$value)
+
+  combined_specs <- unique(p$data$specifications[grepl("c1 + c2", p$data$formula, fixed = TRUE)])
+  has_individual_strikes <- vapply(combined_specs, function(specification) {
+    all(c("c1", "c2") %in% p$data$value[p$data$specifications == specification])
+  }, logical(1))
+
+  expect_true(all(has_individual_strikes))
+})
+
+test_that("all covariates are expanded in the strike plot when controls can be inferred", {
+  specs_simple <- specr::setup(data = example_data,
+                               x = c("x1", "x2"),
+                               y = "y1",
+                               model = "lm",
+                               subsets = list(group1 = unique(example_data$group1)),
+                               controls = c("c1", "c2"),
+                               simplify = TRUE)
+  results_simple <- specr(specs_simple)
+  p <- plot(results_simple, type = "choices", choices = "controls")
+
+  expect_false("all covariates" %in% p$data$value)
+
+  combined_specs <- unique(p$data$specifications[grepl("c1 + c2", p$data$formula, fixed = TRUE)])
+  has_individual_strikes <- vapply(combined_specs, function(specification) {
+    all(c("c1", "c2") %in% p$data$value[p$data$specifications == specification])
+  }, logical(1))
+
+  expect_true(all(has_individual_strikes))
+})
+
 
 # Test 5
 test_that("Function plot.specr.object with `type = 'choices'` creates a ggplot", {
@@ -47,6 +81,5 @@ test_that("Function plot.specr.object with `type = 'choices'` creates a ggplot",
   p <- plot(results, "choices")
   expect_is(p, "gg")
 })
-
 
 


### PR DESCRIPTION
Change the choices panel so control combinations like c1 + c2 are not plotted as their own y-axis entries. Instead, for each specification with a control combination, draw strikes on each individual control row instead.